### PR TITLE
Folds survive buffer kills

### DIFF
--- a/fold-this.el
+++ b/fold-this.el
@@ -53,6 +53,11 @@
   "Face used to highlight the fold overlay."
   :group 'fold-this)
 
+(defcustom fold-this-persistent-folds t
+  "Non-nil means that folds survive buffer kills."
+  :group 'fold-this
+  :type 'boolean)
+
 ;;;###autoload
 (defun fold-this (beg end)
   (interactive "r")
@@ -119,7 +124,8 @@
 
 (defun fold-this--find-file-hook ()
   "A hook restoring fold overlays"
-  (when (and buffer-file-name
+  (when (and fold-this-persistent-folds
+             buffer-file-name
              (not (derived-mode-p 'dired-mode)))
     (let* ((file-name buffer-file-name)
            (cell (assoc file-name fold-this--overlay-alist)))
@@ -132,7 +138,8 @@
 
 (defun fold-this--kill-buffer-hook ()
   "A hook saving overlays"
-  (when (and buffer-file-name
+  (when (and fold-this-persistent-folds
+             buffer-file-name
              (not (derived-mode-p 'dired-mode)))
     (mapc 'fold-this--save-overlay-to-alist
           (overlays-in (point-min) (point-max)))))


### PR DESCRIPTION
As discussed in #3, I had some code preserving fold from being deleted by buffer kills. I did not really finish the code, as I wanted it to be persistent between Emacs sessions, and this feature will probably follow.

All it does basically is add two hooks (find-file/kill-buffer) to save/reload the folds from/to an alist mapping a filename to its overlay positions.