### PR TITLE
Stronger fold persistence (works between Emacs sessions)

### DIFF
--- a/fold-this.el
+++ b/fold-this.el
@@ -145,6 +145,17 @@
           (overlays-in (point-min) (point-max)))))
 (add-hook 'kill-buffer-hook 'fold-this--kill-buffer-hook)
 
+(defun fold-this--walk-buffers-save-overlays ()
+  "Walk the buffer list, save overlays to the alist"
+  (let ((buf-list (buffer-list)))
+    (while buf-list
+      (with-current-buffer (car buf-list)
+        (when (and buffer-file-name
+                   (not (derived-mode-p 'dired-mode)))
+          (mapc 'fold-this--save-overlay-to-alist
+                (overlays-in (point-min) (point-max))))
+        (setq buf-list (cdr buf-list))))))
+
 (defun fold-this--save-overlay-to-alist (overlay)
   "Add an overlay position pair to the alist"
   (when (eq (overlay-get overlay 'type) 'fold-this)

--- a/fold-this.el
+++ b/fold-this.el
@@ -167,6 +167,7 @@
 (add-hook 'kill-emacs-hook 'fold-this--kill-emacs-hook)
 
 (defun fold-this--save-alist-to-file ()
+  (fold-this--clean-unreadable-files)
   (let ((file (expand-file-name fold-this-persistent-folds-file))
         (coding-system-for-write 'utf-8)
         (version-control 'never))
@@ -222,6 +223,19 @@
       (setq fold-this--overlay-alist
             (cons (cons file-name (cons pos overlay-list))
                   fold-this--overlay-alist)))))
+
+(defun fold-this--clean-unreadable-files ()
+  "Check if files in the alist exist and are readable, drop
+  non-existing/non-readable ones"
+  (when fold-this--overlay-alist
+    (let ((orig fold-this--overlay-alist)
+          new)
+      (dolist (cell orig)
+        (let ((fname (car cell)))
+          (when (file-readable-p fname)
+            (setq new (cons cell new)))))
+      (setq fold-this--overlay-alist
+            (nreverse new)))))
 
 (provide 'fold-this)
 ;;; fold-this.el ends here

--- a/fold-this.el
+++ b/fold-this.el
@@ -59,7 +59,7 @@ Emacs sessions."
   :group 'fold-this
   :type 'boolean)
 
-(defcustom fold-this-persistent-folds-file (locate-user-emacs-file "fold-this")
+(defcustom fold-this-persistent-folds-file (locate-user-emacs-file ".fold-this.el")
   "A file to save persistent fold info to."
   :group 'fold-this
   :type 'file)


### PR DESCRIPTION
I've finished the full-blown fold persistence(see issue #3 for the discussion). Now it works between Emacs sessions. 

By default folds are persistent, this behavior is controlled by `fold-this-persistent-folds`. A number of files for which the folds are saved is controlled by `fold-this-persistent-folded-file-limit`. A default file for saving the alist is in `fold-this-persistent-folds-file`.

So, mechanics in short: upon Emacs exit it walks all buffers saving all the folds into the alist. Then it goes over the alist, checking if fold files still exist and the total number of controlled files isn't too big, deleting folds for non-existant files, and folds for older files, that are over the file number limit. Then it dumps the whole thing into a file, restoring it upon first find-file-hook after Emacs restart.