### PR TITLE
Add support for isearch's automatic unfolding/preview

### DIFF
--- a/fold-this.el
+++ b/fold-this.el
@@ -1,4 +1,4 @@
-;;; fold-this.el --- Just fold this region please
+;;; fold-this.el --- Just fold this region please -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2012-2013 Magnar Sveen <magnars@gmail.com>
 
@@ -71,16 +71,27 @@ Emacs sessions."
                  (const :tag "No Limit" nil)))
 
 ;;;###autoload
-(defun fold-this (beg end)
+(defun fold-this (beg end &optional fold-header)
   (interactive "r")
+  (setq fold-header (or fold-header "..."))
   (let ((o (make-overlay beg end nil t nil)))
     (overlay-put o 'type 'fold-this)
     (overlay-put o 'invisible t)
     (overlay-put o 'keymap fold-this-keymap)
+    (overlay-put o 'invisible t)
+    (overlay-put o 'isearch-open-invisible-temporary
+                 (lambda (o action)
+                   (if action
+                       (progn
+                         (overlay-put o 'display (propertize fold-header 'face 'fold-this-overlay))
+                         (overlay-put o 'invisible t))
+                     (progn
+                       (overlay-put o 'display nil)
+                       (overlay-put o 'invisible nil)))))
+    (overlay-put o 'isearch-open-invisible (lambda (o) (fold-this-unfold-at-point)))
     (overlay-put o 'face 'fold-this-overlay)
     (overlay-put o 'modification-hooks '(fold-this--unfold-overlay))
-    (overlay-put o 'display (propertize "." 'face 'fold-this-overlay))
-    (overlay-put o 'before-string (propertize "." 'face 'fold-this-overlay))
+    (overlay-put o 'display (propertize fold-header 'face 'fold-this-overlay))
     (overlay-put o 'evaporate t))
   (deactivate-mark))
 


### PR DESCRIPTION
During an isearch setup we want to search through the folded region and see what's going on.  `isearch` can automatically display the folded region and then collapse it again when it is no longer relevant (i.e. match is outside the region).

I've also added an extra argument to `fold-this` to allow for custom header instead of dots: I'm using this package from an elisp program and I like to see the first line of the region as the "header".