### PR TITLE
Only save alist if buffer modified it.

### DIFF
--- a/fold-this.el
+++ b/fold-this.el
@@ -224,7 +224,8 @@ is in front of a sexp, fold the following sexp."
       (fold-this--load-alist-from-file))
     (mapc 'fold-this--save-overlay-to-alist
           (overlays-in (point-min) (point-max)))
-    (fold-this--save-alist-to-file)))
+    (when (alist-get buffer-file-name fold-this--overlay-alist)
+      (fold-this--save-alist-to-file))))
 
 (defun fold-this--kill-emacs-hook ()
   "A hook saving overlays in all buffers and dumping them into a


### PR DESCRIPTION
* fold-this.el (fold-this--kill-buffer-hook): check if buffer is in alist
  before save it to file.