### PR TITLE
Save whole buffers overlays (don't be restricted on narrowed region)

### DIFF
--- a/fold-this.el
+++ b/fold-this.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2012-2013 Magnar Sveen <magnars@gmail.com>
 
 ;; Author: Magnar Sveen <magnars@gmail.com>
-;; Version: 0.4.1
+;; Version: 0.4.2
 ;; Keywords: convenience
 ;; Homepage: https://github.com/magnars/fold-this.el
 
@@ -222,8 +222,10 @@ is in front of a sexp, fold the following sexp."
     (when (not fold-this--overlay-alist-loaded)
       ;; is it even possible ?
       (fold-this--load-alist-from-file))
-    (mapc 'fold-this--save-overlay-to-alist
-          (overlays-in (point-min) (point-max)))
+    (save-restriction
+      (widen)
+      (mapc 'fold-this--save-overlay-to-alist
+	    (overlays-in (point-min) (point-max))))
     (when (alist-get buffer-file-name fold-this--overlay-alist)
       (fold-this--save-alist-to-file))))
 
@@ -279,12 +281,14 @@ is in front of a sexp, fold the following sexp."
           (setq fold-this--overlay-alist
                 (delq (assoc buffer-file-name fold-this--overlay-alist)
                       fold-this--overlay-alist))
-          (mapc 'fold-this--save-overlay-to-alist
-                (overlays-in (point-min) (point-max))))
+          (save-restriction
+	    (widen)
+	    (mapc 'fold-this--save-overlay-to-alist
+		  (overlays-in (point-min) (point-max)))))
         (setq buf-list (cdr buf-list))))))
 
 (defun fold-this--save-overlay-to-alist (overlay)
-  "Add an overlay position pair to the alist"
+  "Add an OVERLAY position pair to the alist."
   (when (eq (overlay-get overlay 'type) 'fold-this)
     (let* ((pos (cons (1- (overlay-start overlay)) (1+ (overlay-end overlay))))
            (file-name buffer-file-name)


### PR DESCRIPTION
Avoid losing buffers overlays if it's narrowed to a portion without any ones.

* fold-this.el (fold-this--kill-buffer-hook,
  fold-this--walk-buffers-save-overlays): save restriction and widen before saving overlays.

I feel this more natural than only save the narrowed region, bu you may have another opinion