### PR TITLE
Fixes error when unfold region (regression in commit #4e80a60).

### DIFF
--- a/fold-this.el
+++ b/fold-this.el
@@ -187,10 +187,10 @@ If narrowing is active, only in it."
   (mapc 'fold-this--delete-my-overlay
         (overlays-at (point))))
 
-(defun fold-this--delete-my-overlay (overlay _after? _beg _end &optional _length)
+(defun fold-this--delete-my-overlay (overlay &optional _after? _beg _end _length)
   "Delete the OVERLAY overlays only if it's an `fold-this'."
-  (when (eq (overlay-get it 'type) 'fold-this)
-    (delete-overlay it)))
+  (when (eq (overlay-get overlay 'type) 'fold-this)
+    (delete-overlay overlay)))
 
 ;;; Fold-this overlay persistence
 ;;


### PR DESCRIPTION
* fold-this.el (fold-this--delete-my-overlay): change signature and
  use of right parameter name.

avoid error like below when trying to unfold a region:
```
mapc: Wrong number of arguments: ((t) (overlay _after\? _beg _end &optional _length) "Delete the OVERLAY overlays only if it's an `fold-this'." (if (eq (overlay-get it 'type) 'fold-this) (progn (delete-overlay it)))), 1
```
P.S.
I * really * need to make an effort in my regression tests !